### PR TITLE
Fix nomad_groups array nested inside another array

### DIFF
--- a/NoMAD_group_condition.sh
+++ b/NoMAD_group_condition.sh
@@ -41,7 +41,7 @@ plist_loc="${managedinstalldir}/ConditionalItems"
 nomad_groups=$(${defaults} read /Users/${last_user}/Library/Preferences/com.trusourcelabs.NoMAD.plist Groups)
 
 # write NoMAD groups to a plist
-${defaults} write "$plist_loc" "nomad_groups" -array "${nomad_groups[@]}"
+${defaults} write "$plist_loc" "nomad_groups" "${nomad_groups[@]}"
 
 # convert the plist from binary to xml
 ${plutil} -convert xml1 "$plist_loc".plist


### PR DESCRIPTION
`$nomad_groups` is already an array so when you write it to the plist with `-array`, it gets nested inside another loop.

By removing `-array`, the `nomad_groups` will be properly stored in a single, un-nested array.

This ensures that munki sees each group as a separate item and will properly work with manifests using munki-conditions that rely on nomad_groups.